### PR TITLE
feat(hours): support different questions for each volunteer role

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "react-paypal-button-v2": "^2.6.3",
     "react-transition-group": "^4.4.1",
     "swr": "^1.0.0",
-    "tailwindcss": "^2.2.15"
+    "tailwindcss": "^2.2.15",
+    "yaml": "^1.10.2"
   },
   "devDependencies": {
     "@types/react": "^17.0.20",

--- a/src/pages/api/addHours.ts
+++ b/src/pages/api/addHours.ts
@@ -19,7 +19,7 @@ export default async function handler(
   const session = await getSession({ req })
   const email = session.user?.email
 
-  const { hours, response } = req.body
+  const { hours, response, role } = req.body
   const name = session?.user?.name
 
   if (!name) return res.status(400).json({ error: "Name is required" })
@@ -28,6 +28,8 @@ export default async function handler(
     return res.status(400).json({ error: "Hours must be a number" })
   if (!response || !isNaN(response))
     return res.status(400).json({ error: "Response is required" })
+  if (!role || !isNaN(role))
+    return res.status(400).json({ error: "Role is required" })
 
   if (
     !Object.keys(VolunteerInfo).some(key =>
@@ -48,9 +50,9 @@ export default async function handler(
     time,
     email,
     hours,
-    response
+    response,
+    role,
   })
-
   ;(async function () {
     const doc = new GoogleSpreadsheet(SHEETS_METADATA.spreadSheetId)
 
@@ -58,7 +60,14 @@ export default async function handler(
     await doc.loadInfo()
 
     const sheet = doc.sheetsByIndex[0]
-    await sheet.addRow({"Timestamp": time, "Name": name, "Email": email, "Hours": hours, "Response": YAML.stringify(response) })
+    await sheet.addRow({
+      Timestamp: time,
+      Name: name,
+      Email: email,
+      Hours: hours,
+      Response: YAML.stringify(response),
+      Role: role,
+    })
   })()
 
   return res.status(200).json({

--- a/src/pages/api/getHours.ts
+++ b/src/pages/api/getHours.ts
@@ -4,12 +4,15 @@ import { GoogleSpreadsheet } from "google-spreadsheet"
 import { getSession } from "next-auth/client"
 import { SHEETS_API_CREDS, SHEETS_METADATA } from "../../../config"
 import { db } from "../../../firebase"
-
+import YAML from "yaml"
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
   const session = await getSession({ req })
+
+  if (!session)
+    return res.status(400).json({ error: "Please sign in through the portal" })
 
   const email = session?.user?.email
 
@@ -22,47 +25,24 @@ export default async function handler(
       return doc.data()
     })
 
-  if (!session)
-    return res.status(400).json({ error: "Please sign in through the portal" })
-
-    // //@ts-ignore
-    // if (!information[username])
-    //   return res.status(303).json({ message: "Username not found" })
-    // //@ts-ignore
-    // if (information[username].password !== password)
-    //   return res.status(400).json({ message: "Password is incorrect" })
+  // //@ts-ignore
+  // if (!information[username])
+  //   return res.status(303).json({ message: "Username not found" })
+  // //@ts-ignore
+  // if (information[username].password !== password)
+  //   return res.status(400).json({ message: "Password is incorrect" })
   ;(async function () {
-    const doc = new GoogleSpreadsheet(SHEETS_METADATA.spreadSheetId)
-
-    await doc.useServiceAccountAuth(SHEETS_API_CREDS)
-    await doc.loadInfo()
-
-    const sheet = doc.sheetsByIndex[0]
-    const rows = await sheet.getRows()
-    const rowsLength = rows.length + 1
-    console.log(`Sheet Title ${sheet.title}`)
-    console.log(`Sheet Length ${rowsLength}`)
-
-    await sheet.loadCells(`A2:C${rowsLength}`)
-    await sheet.loadCells(`C2:C${rowsLength}`)
-    await sheet.loadCells(`D2:D${rowsLength}`)
-    await sheet.loadCells(`E2:E${rowsLength}`)
-    await sheet.loadCells(`F2:F${rowsLength}`)
-
-    let totalHours = 0
-    let data = []
-
     // identify volunteer alias
-    let volunteerInfo = Object.entries(VolunteerInfo).find(volunteer => {
+    let volunteerRecord = Object.entries(VolunteerInfo).find(volunteer => {
       // @ts-ignore
       return volunteer[1]?.emails?.includes(email)
     })
 
     // console.log(volunteerInfo)
-
-    if (volunteerInfo?.length > 1 && volunteerInfo[1]) {
+    let volunteerInfo;
+    if (volunteerRecord?.length > 1 && volunteerRecord[1]) {
       // @ts-ignore
-      volunteerInfo = volunteerInfo[1]
+      volunteerInfo = volunteerRecord[1]
     }
 
     // console.log(volunteerInfo)
@@ -73,9 +53,44 @@ export default async function handler(
           "No volunteer found, make sure you're signed in with the right email. Or, this is your first time.",
       })
 
-    for (let i = 2; i <= rowsLength; i++) {
+    const doc = new GoogleSpreadsheet(SHEETS_METADATA.spreadSheetId)
+
+    await doc.useServiceAccountAuth(SHEETS_API_CREDS)
+    await doc.loadInfo()
+
+    const hourSheet = doc.sheetsByIndex[0]
+    const hourSheetRows = await hourSheet.getRows()
+    const hourSheetRowLength = hourSheetRows.length + 1
+    console.log(`Sheet Title ${hourSheet.title}`)
+    console.log(`Sheet Length ${hourSheetRowLength}`)
+
+    const rolesSheet = doc.sheetsByIndex[1]
+    const rolesSheetRows = await rolesSheet.getRows()
+    const cols = rolesSheet.headerValues
+    const rolesSheetRowLength = rolesSheetRows.length + 1
+    // load questions for each role and all responses
+    await Promise.all([
+      rolesSheet.loadCells(`A2:${String.fromCharCode(65 + cols.length-1)}${rolesSheetRowLength}`),
+      // timestamp col
+      hourSheet.loadCells(`A2:A${hourSheetRowLength}`),
+      // name col
+      hourSheet.loadCells(`B2:B${hourSheetRowLength}`),
+      // email col
+      hourSheet.loadCells(`C2:C${hourSheetRowLength}`),
+      // hrs col
+      hourSheet.loadCells(`D2:D${hourSheetRowLength}`),
+      // response col
+      hourSheet.loadCells(`E2:E${hourSheetRowLength}`),
+    ])
+
+    let totalHours = 0
+    let data = []
+    
+    const role = volunteerInfo?.role
+
+    for (let i = 2; i <= hourSheetRowLength; i++) {
       const findData = async () => {
-        let time = await sheet.getCellByA1(`A${i}`)
+        let time = await hourSheet.getCellByA1(`A${i}`)
         // console.log(i, time.effectiveFormat?.numberFormat?.type);
         time =
           time.effectiveFormat?.numberFormat?.type === "DATE_TIME"
@@ -84,10 +99,9 @@ export default async function handler(
         // const temp = await sheet.getCellByA1(`A${i}`)
         // console.log(temp.numberFormat);
         // console.log(i, time, temp.numberFormat);
-        const em = await sheet.getCellByA1(`C${i}`).value
-        const prs = await sheet.getCellByA1(`D${i}`).value
-        const hrs = await sheet.getCellByA1(`E${i}`).value
-        const other = await sheet.getCellByA1(`F${i}`).value
+        const em = await hourSheet.getCellByA1(`C${i}`).value
+        const hrs = await hourSheet.getCellByA1(`D${i}`).value
+        const response = YAML.parse(await hourSheet.getCellByA1(`E${i}`).value)
 
         if (
           // @ts-ignore
@@ -97,16 +111,25 @@ export default async function handler(
         ) {
           console.log("found", i, parseFloat(hrs))
           totalHours += parseFloat(hrs) || 0 // default to 0 if not a number
-          data = [...data, { time, em, prs, hrs, other }]
+          data = [...data, { time, em, hrs, response }]
         }
       }
 
       await findData()
     }
 
+    const roleCol = cols.findIndex(col => role === col)
+    let questions = []
+    for (let i = 2; i <= rolesSheetRowLength; i++) {
+      const cell = `${String.fromCharCode(65 + roleCol)}${i}`
+      questions.push(await rolesSheet.getCellByA1(cell).value)
+    }
+
+    questions = questions.filter(q => q)
+
     // @ts-ignore
     data = data.sort((a, b) => new Date(b.time) - new Date(a.time))
 
-    return res.status(200).json({ totalHours, data })
+    return res.status(200).json({ totalHours, questions, data, role })
   })()
 }

--- a/src/pages/view-hours.tsx
+++ b/src/pages/view-hours.tsx
@@ -1,5 +1,5 @@
 import { signIn, signOut, useSession } from "next-auth/client"
-import React, { Fragment } from "react"
+import React, { Fragment, useEffect, useReducer } from "react"
 import Header from "../components/Header"
 import Layout from "../components/Layout"
 import SEO from "../components/SEO"
@@ -16,7 +16,7 @@ export function VolunteerHourHistory({ data }) {
         {data &&
           !data?.error &&
           data.data.map(item => (
-            <li key={item.id} className="py-4">
+            <li key={item.time} className="py-4">
               <div className="flex space-x-3">
                 <div className="flex-1 space-y-1">
                   <div className="flex items-center justify-between">
@@ -25,13 +25,16 @@ export function VolunteerHourHistory({ data }) {
                     </h3>
                     <p className="text-sm text-gray-500">{item.hrs} hours</p>
                   </div>
-                  {item?.prs && (
-                    <p className="text-sm text-gray-500">{item.prs}</p>
-                  )}
-                  {item.other && (
-                    <p className="text-sm text-gray-500">
-                      <b>Other information:</b> {item.other}
-                    </p>
+                  {item.response && (
+                    <div className="flex flex-col space-y-1">
+                      {Object.entries(item.response).map((pair) => {
+                        return (
+                            <span className="text-sm text-gray-500 whitespace-pre" key={`${item.time}_${pair[0]}`}>
+                              <b>{pair[0]}:</b>{" "}{pair[1]}
+                            </span>
+                          )
+                        })}
+                    </div>
                   )}
                 </div>
               </div>
@@ -42,14 +45,21 @@ export function VolunteerHourHistory({ data }) {
   )
 }
 
-export function AddVolunteerHoursForm({ data }) {
+function reducer(state, action) {
+  return {...state, [action.q]: action.value}
+}
+
+export function AddVolunteerHoursForm({data}) {
+  const initialState = {}
+  data?.questions.forEach(question => {
+    initialState[question] = ""
+  })
+  const [state, dispatch] = useReducer(reducer, initialState);
   const [response, setResponse] = React.useState(null)
-  const [name, setName] = React.useState("")
   const [hours, setHours] = React.useState("")
-  const [prsReviewed, setPrsReviewed] = React.useState("")
-  const [other, setOther] = React.useState("")
   const [error, setError] = React.useState("")
   const [loading, setLoading] = React.useState(false)
+  // useEffect(()=>console.log("state", state),[state])
   const submitHours = () => {
     setLoading(true)
     setError("")
@@ -60,10 +70,8 @@ export function AddVolunteerHoursForm({ data }) {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        name,
-        hours: hours,
-        prsReviewed,
-        other,
+        hours,
+        response: state
       }),
     })
       .then(res => res.json())
@@ -110,35 +118,27 @@ export function AddVolunteerHoursForm({ data }) {
         </label>
         <input
           onChange={e => setHours(e.target.value)}
-          type="text"
+          type="number"
           name="job-title"
           id="job-title"
           className="block w-full border-0 p-0 text-gray-900 placeholder-gray-500 focus:ring-0"
           placeholder="Ex. 42"
         />
       </div>
-      <div className="relative border border-gray-300 px-3 py-2 focus-within:z-10 focus-within:ring-1 focus-within:ring-indigo-600 focus-within:border-indigo-600">
-        <label className="block w-full text-sm font-medium text-gray-700">
-          What did you do this week (pull requests, classes taught, etc.)
-        </label>
-        <textarea
-          onChange={e => setPrsReviewed(e.target.value)}
-          rows={8}
-          className="block w-full border-0 p-0 text-gray-900 placeholder-gray-500 focus:ring-0"
-          placeholder="Ex. I reviewed pull requests #1,2,3 and taught the USACO Bronze class"
-        />
-      </div>
-      <div className="relative border border-gray-300 rounded-md rounded-t-none px-3 py-2 focus-within:z-10 focus-within:ring-1 focus-within:ring-indigo-600 focus-within:border-indigo-600">
-        <label className="block w-full text-sm font-medium text-gray-700">
-          Is there anything else you would like to add?
-        </label>
-        <textarea
-          rows={5}
-          onChange={e => setOther(e.target.value)}
-          className="block w-full border-0 p-0 text-gray-900 placeholder-gray-500 focus:ring-0"
-          placeholder="Ex. The majority of my time was dedicated to creating visualizations."
-        />
-      </div>
+      {data?.questions.map((q) => (
+        <div key={`question_form_${q}`} className="relative border border-gray-300 rounded-md rounded-t-none px-3 py-2 focus-within:z-10 focus-within:ring-1 focus-within:ring-indigo-600 focus-within:border-indigo-600">
+          <label className="block w-full text-sm font-medium text-gray-700">
+            {q}
+          </label>
+          <textarea
+            rows={5}
+            onChange={e => dispatch({q, value: e.target.value})}
+            value={state[q]}
+            className="block w-full border-0 p-0 text-gray-900 placeholder-gray-500 focus:ring-0"
+            placeholder="Enter your text here..."
+          />
+        </div>
+      ))}
       {error && (
         <div className="w-full flex flex-row p-1 bg-red-200 my-2 rounded-md text-red-800">
           {/* Error Icon */}
@@ -181,7 +181,7 @@ export function AddVolunteerHoursForm({ data }) {
       )}
       <div className="w-full p-1">
         Your last request was made on:{" "}
-        {new Date(data?.length >= 1 && data[0]?.time)?.toDateString()}
+        {new Date(data.data?.length >= 1 && data.data[0]?.time)?.toDateString()}
       </div>
 
       <button
@@ -222,19 +222,24 @@ export default function ViewHours() {
             <div className="w-full mt-4 mb-10">
               <div className="grid w-full grid-rows-6 grid-cols-none md:grid-rows-2 md:grid-cols-1 md:grid-flow-col gap-3">
                 <div className="row-span-3 bg-white p-3 flex flex-col rounded-md shadow-lg text-5xl font-extrabold">
-                  <h1 className="m-auto text-purple-900 underline">
+                  <h1 className="m-auto text-purple-900 underline text-center">
                     {session?.user?.name}
                   </h1>
                   <h3 className="mx-auto mb-6 text-purple-800 text-sm">
                     Email: {session?.user?.email}
                   </h3>
+                  
                 </div>
                 <div className="flex bg-white flex-col px-3 py-5 col-span-2 row-span-2 rounded-lg shadow-lg">
                   {data ? (
-                    <p className="text-purple-800 font-semibold text-3xl m-auto">
+                    <><p className="text-purple-800 font-semibold text-3xl m-auto">
                       <b>{Math.round(data?.totalHours * 100) / 100}</b> hours
                       volunteered
                     </p>
+                    <p className="text-purple-800 font-semibold text-2xl m-auto">
+                      <b>Current Role: </b>{data?.role}
+                    </p>
+                    </>
                   ) : (
                     // spinner
                     <div className="flex items-center justify-center ">
@@ -331,7 +336,7 @@ export default function ViewHours() {
                         Add your hours
                       </Dialog.Title>
 
-                      <AddVolunteerHoursForm data={data?.data} />
+                      <AddVolunteerHoursForm data={data} />
 
                       {/* <div className="">
                         <button


### PR DESCRIPTION
This PR adds support for unique questions for each volunteer role. 

Some changes will need to be made to the Google sheet. The first sheet now only has 5 columns - `Timestamp`, `Name`, `Email`, `Hours`, and a generic `Response` field. The Response cell is formatted as YAML so it's easy to parse each question if needed, while still supporting multi-line strings and being human-readable.
 <details>
  <summary><b>New hours sheet format</b></summary>
  
  Timestamp | Name | Email | Hours | Response | Role
-- | -- | -- | -- | --
2021-11-21T20:42:44.795Z | Jason Antwi-Appah | hey@jasonaa.me | 9 | What else did you do: NothingWhat PRs did you work on:  \|  here is a nice multiline string.  not sure what else to say haha | Web Dev
</details>


A second sheet has been added to store roles and their respective questions. 
<details>
  <summary><b>Roles Sheet Format</b></summary>
  
  Web Dev | Magician
-- | --
What PRs did you work on? | What are your favorite spells?
Anything else you'd like to mention? | What house are you in?
  | Preferred wand?
</details>

~Finally, in the `volunteers` Firestore document, each volunteer should have a `role` property assigned to the name of a role that exists in the Google Sheet (like Web Dev or Magician).~ Edit: 981ce28 replaces this with an additional column in the hours sheet







