### PR TITLE
Add normalization for line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*   text=auto


### PR DESCRIPTION
PR adds a `.gitattributes` file to normalize line endings and prevent conflicts between platforms.