### PR TITLE
change email on contact us section on contests page

### DIFF
--- a/src/pages/contests.tsx
+++ b/src/pages/contests.tsx
@@ -471,8 +471,8 @@ export default function Contests() {
                 </h3>
                 <p className="text-gray-600">
                   Email{" "}
-                  <a href="mailto:melodyyu@joincpi.org" className="underline">
-                    melodyyu@joincpi.org
+                  <a href="mailto:aakashgokhale@joincpi.org" className="underline">
+                    aakashgokhale@joincpi.org
                   </a>{" "}
                   with information about your contest to apply.
                 </p>


### PR DESCRIPTION
Test required by @Vinceyou1 
Change contact us email on contests page from melodyyu@joincpi.org to aakashgokhale@joincpi.org.