### PR TITLE
Class Updates

### DIFF
--- a/src/components/classes/ClassLevels.tsx
+++ b/src/components/classes/ClassLevels.tsx
@@ -45,7 +45,7 @@ export default function ClassLevels() {
                 <div className="flex-1 flex flex-col justify-between px-6 pt-6 pb-8 bg-gray-50 space-y-6 sm:p-10 sm:pt-6">
                   <ul className="space-y-4">
                     {[
-                      "Sundays, 5-7pm PDT during 6/22/25 to 8/24/25.",
+                      "Sundays, 5-7pm PDT during 9/21/25 to 11/23/25.",
                       "File / Fast I/O",
                       "Time Complexity",
                       "Data Structures and Simulation",
@@ -117,7 +117,7 @@ export default function ClassLevels() {
                 <div className="flex-1 flex flex-col justify-between px-6 pt-6 pb-8 bg-gray-50 space-y-6 sm:p-10 sm:pt-6">
                   <ul className="space-y-4">
                     {[
-                      "Saturdays, 4-6pm PDT during 6/21/25 to 8/23/25.",
+                      "Saturdays, 4-6pm PDT during 9/20/25 to 11/22/25.",
                       "Prefix Sums",
                       "Sorting with Custom Comparators",
                       "Two Pointers",

--- a/src/components/classes/registration/CourseSelectionSection.tsx
+++ b/src/components/classes/registration/CourseSelectionSection.tsx
@@ -63,10 +63,8 @@ export default function CourseSelectionSection({ level, setLevel }) {
 
                 <p className="mt-2 text-sm text-gray-500">
                   {level == "beginner"
-
-                    ? "Every Sunday (excluding USACO weekends) from June 22 - August 24 , 5-7pm PDT. (Total 10 Sessions)"
-                    : "Every Saturday (excluding USACO weekends) from June 21 - August 23, 4-6pm PDT. (Total 10 Sessions)"}
-
+                    ? "Every Sunday (excluding USACO weekends) from September 21 - November 23 , 5-7pm PDT. (Total 10 Sessions)"
+                    : "Every Saturday (excluding USACO weekends) from September 20 - November 22, 4-6pm PDT. (Total 10 Sessions)"}
                 </p>
               </div>
             )}

--- a/src/pages/api/classes/approve-live-financial-aid.ts
+++ b/src/pages/api/classes/approve-live-financial-aid.ts
@@ -32,7 +32,7 @@ export default async function approveFinancialAid(
     const joinLinkRef = db.collection("group-join-links").doc()
     await joinLinkRef.set({
       groupId:
-        level === "beginner" ? "ikVi2W7h0Wu1pLY7UV3g" : "8H2mTXE3dDn9qRuRx2cg",
+        level === "beginner" ? "9EPv4ex9P8F65LoG93Ym" : "mQcCxGc2mZgkOrcpdFt3",
       revoked: false,
       numUses: 0,
       maxUses: 1,
@@ -52,7 +52,7 @@ export default async function approveFinancialAid(
       }),
       db
         .collection("classes-registration")
-        .doc("2025feb")
+        .doc("2025oct")
         .collection("registrations")
         .doc(registrationId)
         .update({

--- a/src/pages/api/classes/process-live-registration.ts
+++ b/src/pages/api/classes/process-live-registration.ts
@@ -69,7 +69,7 @@ export default async function processLiveRegistration(
     }
     const ref = db
       .collection("classes-registration")
-      .doc("2025feb")
+      .doc("2025oct")
       .collection("registrations")
       .doc()
     console.log(
@@ -79,7 +79,7 @@ export default async function processLiveRegistration(
     const joinLinkRef = db.collection("group-join-links").doc()
     await joinLinkRef.set({
       groupId:
-        level === "beginner" ? "ikVi2W7h0Wu1pLY7UV3g" : "8H2mTXE3dDn9qRuRx2cg",
+        level === "beginner" ? "9EPv4ex9P8F65LoG93Ym" : "mQcCxGc2mZgkOrcpdFt3",
       revoked: false,
       numUses: 0,
       maxUses: 1,

--- a/src/pages/classes.tsx
+++ b/src/pages/classes.tsx
@@ -29,7 +29,7 @@ export default function Classes() {
                   <div className="mx-auto lg:ml-0 max-w-md px-4 sm:max-w-2xl sm:px-6 sm:text-center lg:px-0 lg:text-left lg:flex lg:items-center lg:col-span-5">
                     <div className="lg:py-24">
                       <span className="text-base font-semibold tracking-wider text-cyan-300 uppercase sm:mt-5 lg:mt-6">
-                        Summer 2025 Session
+                        Fall 2025 Session
                       </span>
                       <h1 className="text-4xl tracking-tight font-extrabold text-white sm:text-6xl xl:text-6xl mt-2">
                         <span className="block">Live Online</span>
@@ -507,11 +507,11 @@ export default function Classes() {
                   <h3>Class Schedule</h3>
                   <ul>
                     <li>
-                      Bronze: Sundays during <b>June 22th - Aug 24th</b> from
+                      Bronze: Sundays during <b>Sept 21th - Nov 23rd</b> from
                       5:00 PM - 7:00 PM PDT
                     </li>
                     <li>
-                      Silver: Saturdays during <b>June 21st - Aug 23rd</b> from
+                      Silver: Saturdays during <b>Sept 20th - Nov 22nd</b> from
                       4:00 PM - 6:00 PM PDT
                     </li>
                   </ul>


### PR DESCRIPTION
I updated the `groupId` property of the `joinLinkRef` in `src/pages/api/classes/process-live-registration.ts`
and `src/pages/api/classes/approve-live-financial-aid.ts`. I also updated the dates in both of these files to be `2025oct`. 

I also updated the `/classes` and `/classes/registration` pages to include the correct dates for the Fall 2025 session.

Bronze: Sundays during Sept 21th - Nov 23rd from 5:00 PM - 7:00 PM PDT

Silver: Saturdays during Sept 20th - Nov 22nd from 4:00 PM - 6:00 PM PDT