### PR TITLE
Close outdated tournament registration link

### DIFF
--- a/src/pages/tournament.tsx
+++ b/src/pages/tournament.tsx
@@ -123,11 +123,12 @@ export default function Tournament() {
               Saturday, March 14th, 2026 <br /> 10:30 AM - 1:30 PM PDT
             </h2>
             <div className="flex flex-col items-stretch  ml-auto mr-auto">
+              {/* Remove 'pointer-events-none' to reopen the link */}
               <Link
-                className="text-center flex-grow mx-auto text-white bg-[#8976ff]/100 rounded-lg focus:translate-y-1 hover:underline transition-all duration-150 mt-4 2xl:text-xl lg:text-lg text-base px-12 py-2"
+                className="pointer-events-none text-center flex-grow mx-auto text-white bg-[#8976ff]/100 rounded-lg focus:translate-y-1 hover:underline transition-all duration-150 mt-4 2xl:text-xl lg:text-lg text-base px-12 py-2"
                 href="http://contest.joincpi.org"
               >
-                Register now!
+                Closed!
               </Link>
             </div>
 


### PR DESCRIPTION
**Before**
<img width="1440" height="744" alt="Screenshot 2026-07-18 at 7 22 01 PM" src="https://github.com/user-attachments/assets/eddaf7c9-ba29-4893-b440-b7709a2eee22" />

**After**
<img width="1440" height="747" alt="Screenshot 2026-07-18 at 7 20 00 PM" src="https://github.com/user-attachments/assets/f95b8e80-8679-4587-9521-ff0c98eacf76" />