### PR TITLE
Fix mobile clipping issues on index, tournament, and contest pages

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -13,3 +13,10 @@
 html {
     overflow-y: scroll
 }
+
+/* fixes mobile clipping issues */
+html, body {
+    max-width: 100vw;
+    overflow-x: hidden;
+    position: relative;
+}


### PR DESCRIPTION
**Before**
<img width="372" height="664" alt="Screenshot 2026-07-21 at 12 00 38 PM" src="https://github.com/user-attachments/assets/04c16086-7b8c-4c1a-878d-26d6f929af19" />

<img width="372" height="664" alt="Screenshot 2026-07-21 at 12 03 07 PM" src="https://github.com/user-attachments/assets/c92982b3-abe9-4c3b-b07a-a020037d8abd" />

<img width="372" height="661" alt="Screenshot 2026-07-21 at 12 08 43 PM" src="https://github.com/user-attachments/assets/7dc1d5d9-ce95-408e-a47f-60ddc13257d3" />

**After**
<img width="372" height="662" alt="Screenshot 2026-07-21 at 12 02 15 PM" src="https://github.com/user-attachments/assets/a4c2692f-6b82-4967-bbf7-96e65154a752" />

<img width="371" height="663" alt="Screenshot 2026-07-21 at 12 04 15 PM" src="https://github.com/user-attachments/assets/afaf4cc5-6717-4d05-8949-c6218d48094e" />

<img width="372" height="661" alt="Screenshot 2026-07-21 at 12 09 57 PM" src="https://github.com/user-attachments/assets/79a0e566-c00b-4d8e-a2f0-1fd5a7ef33d6" />