### PR TITLE
Fix Ui: reveal missing message text on small screens

### DIFF
--- a/src/pages/bronze-video-classes.tsx
+++ b/src/pages/bronze-video-classes.tsx
@@ -30,7 +30,7 @@ export default function Classes() {
             <div className="pt-10 bg-gray-900 sm:pt-16 lg:pt-8 lg:pb-14 lg:overflow-hidden">
               <div className="mx-auto max-w-7xl lg:px-8">
                 <div className="lg:grid lg:grid-cols-8 lg:gap-8">
-                  <div className="mx-auto lg:ml-0 max-w-md px-4 sm:max-w-2xl sm:px-6 sm:text-center lg:px-0 lg:text-left lg:flex lg:items-center lg:col-span-5">
+                  <div className="mx-auto lg:ml-0 max-w-md px-4 sm:max-w-2xl sm:px-6 sm:text-center lg:px-0 lg:text-left lg:flex lg:items-center lg:col-span-5 relative z-10">
                     <div className="lg:py-24">
                       <h1 className="text-4xl tracking-tight font-extrabold text-white sm:text-6xl xl:text-6xl mt-2">
                         <span
@@ -80,7 +80,7 @@ export default function Classes() {
                       </p>
                     </div>
                   </div>
-                  <div className="mt-12 -mb-16 sm:-mb-48 lg:mt-10 lg:-mb-16 lg:relative lg:col-span-3">
+                  <div className="mt-0 mb-0 sm:-mb-48 lg:mt-10 lg:-mb-16 lg:relative lg:col-span-3">
                     <div className="mx-auto max-w-md px-4 sm:max-w-xl sm:px-6 lg:max-w-none lg:px-0">
                       {/* Illustration taken from Lucid Illustrations: https://lucid.pixsellz.io/ */}
                       <Image

--- a/src/pages/silver-video-classes.tsx
+++ b/src/pages/silver-video-classes.tsx
@@ -30,7 +30,7 @@ export default function Classes() {
             <div className="pt-10 bg-gray-900 sm:pt-16 lg:pt-8 lg:pb-14 lg:overflow-hidden">
               <div className="mx-auto max-w-7xl lg:px-8">
                 <div className="lg:grid lg:grid-cols-8 lg:gap-8">
-                  <div className="mx-auto lg:ml-0 max-w-md px-4 sm:max-w-2xl sm:px-6 sm:text-center lg:px-0 lg:text-left lg:flex lg:items-center lg:col-span-5">
+                  <div className="mx-auto lg:ml-0 max-w-md px-4 sm:max-w-2xl sm:px-6 sm:text-center lg:px-0 lg:text-left lg:flex lg:items-center lg:col-span-5 relative z-10">
                     <div className="lg:py-24">
                       <h1 className="text-4xl tracking-tight font-extrabold text-white sm:text-6xl xl:text-6xl mt-2">
                         <span
@@ -80,7 +80,7 @@ export default function Classes() {
                       </p>
                     </div>
                   </div>
-                  <div className="mt-12 -mb-16 sm:-mb-48 lg:mt-10 lg:-mb-16 lg:relative lg:col-span-3">
+                  <div className="mt-0 mb-0 sm:-mb-48 lg:mt-10 lg:-mb-16 lg:relative lg:col-span-3">
                     <div className="mx-auto max-w-md px-4 sm:max-w-xl sm:px-6 lg:max-w-none lg:px-0">
                       {/* Illustration taken from Lucid Illustrations: https://lucid.pixsellz.io/ */}
                       <Image


### PR DESCRIPTION
On mobile, the "looking for live classes?" link would not show up on the bronze and silver self study class pages.

### **Before**

**Bronze page:** 

<img width="374" height="660" alt="Screenshot 2026-07-23 at 7 04 36 PM" src="https://github.com/user-attachments/assets/c198212d-eb5a-4837-992d-3e75f5f489d9" />

**Silver page:**

<img width="372" height="661" alt="Screenshot 2026-07-23 at 7 12 50 PM" src="https://github.com/user-attachments/assets/55fe978f-d855-4fd2-9326-a6ee71eb75db" />


### **After**

**Bronze page:**

<img width="373" height="664" alt="Screenshot 2026-07-23 at 7 06 16 PM" src="https://github.com/user-attachments/assets/0495a9ed-de17-4a95-8b19-1cbaf320df4b" />

**Silver page:**

<img width="372" height="661" alt="Screenshot 2026-07-23 at 7 13 07 PM" src="https://github.com/user-attachments/assets/5aef0a8c-ccd4-40e5-9d32-4c206b7f3e1a" />