### PR TITLE
Contests page ui fix: un-hide hero header text on mobile devices

### DIFF
--- a/src/pages/contests.tsx
+++ b/src/pages/contests.tsx
@@ -28,7 +28,7 @@ export default function Contests() {
               style={{ mixBlendMode: "multiply" }}
             />
           </div>
-          <div className="relative px-4 py-16 sm:px-6 sm:py-24 lg:py-32 lg:px-8">
+          <div className="relative px-4 pt-32 pb-16 sm:px-6 sm:py-24 lg:py-32 lg:px-8">
             <h1 className="text-center text-4xl text-white font-extrabold tracking-tight sm:text-5xl lg:text-6xl">
               Programming Contests <br />
               <span className="text-purple-300">for High Schoolers.</span>


### PR DESCRIPTION
The "Programming Contests" heading text does not show on mobile screens because of padding issues.

**Before ----------------------------------- After**

<img width="217" height="471" alt="Screenshot 2026-07-24 at 6 19 37 PM" src="https://github.com/user-attachments/assets/bee5ddae-f093-4266-9a58-5335065feda9" /> <img width="216" height="468" alt="Screenshot 2026-07-24 at 6 20 00 PM" src="https://github.com/user-attachments/assets/8eaf1149-03ed-4e8b-a404-e37e09df14fd" />


